### PR TITLE
Redirect site to https://docs.publishing.service.gov.uk/analytics/

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -33,3 +33,5 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 
 gem "webrick", "~> 1.7"
+
+gem "jekyll-redirect-from"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -265,6 +265,7 @@ DEPENDENCIES
   github-pages (~> 227)
   http_parser.rb (~> 0.6.0)
   jekyll-feed (~> 0.12)
+  jekyll-redirect-from
   minima (~> 2.5)
   tzinfo (>= 1, < 3)
   tzinfo-data

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -59,7 +59,7 @@ defaults:
 # Build settings
 plugins:
   - jekyll-feed
-
+  - jekyll-redirect-from
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,6 @@
 ---
 title: Google Analytics 4 Implementation record
+redirect_to: https://docs.publishing.service.gov.uk/analytics/
 ---
 <h1 class="govuk-heading-l">{{ page.title }}</h1>
 <p class="govuk-body">This site contains a record of the data implementation for Google Analytics 4 on GOV.UK Publishing. It has been built as an aid to developers on GOV.UK Publishing but is being made available for anyone who may find our approach useful.</p>

--- a/docs/pages/approach.html
+++ b/docs/pages/approach.html
@@ -1,6 +1,7 @@
 ---
 title: Developer approach
 layout: layout_docs
+redirect_to: https://docs.publishing.service.gov.uk/analytics/approach.html
 ---
 <h1 class="govuk-heading-l">{{ page.title }}</h1>
 

--- a/docs/pages/attributes.html
+++ b/docs/pages/attributes.html
@@ -1,6 +1,7 @@
 ---
 title: Attributes
 layout: layout_data
+redirect_to: https://docs.publishing.service.gov.uk/analytics/attributes.html
 ---
 <h1 class="govuk-heading-l">{{ page.title }}</h1>
 <p class="govuk-body">Attributes are the key/value pairs of data inside events. Attributes are often used by more than one event.</p>

--- a/docs/pages/events.html
+++ b/docs/pages/events.html
@@ -1,6 +1,7 @@
 ---
 title: Events
 layout: layout_data
+redirect_to: https://docs.publishing.service.gov.uk/analytics/events.html
 ---
 <h1 class="govuk-heading-l">{{ page.title }}</h1>
 <p class="govuk-body">Events are collections of data that are sent to Google Analytics when users do certain things, like opening an accordion or clicking certain links.</p>

--- a/docs/pages/index_data.html
+++ b/docs/pages/index_data.html
@@ -1,6 +1,7 @@
 ---
 title: Data
 layout: layout_data
+redirect_to: https://docs.publishing.service.gov.uk/analytics/data.html
 ---
 <h1 class="govuk-heading-l">{{ page.title }}</h1>
 

--- a/docs/pages/index_docs.html
+++ b/docs/pages/index_docs.html
@@ -1,6 +1,7 @@
 ---
 title: Documentation
 layout: layout_docs
+redirect_to: https://docs.publishing.service.gov.uk/analytics/docs.html
 ---
 <h1 class="govuk-heading-l">{{ page.title }}</h1>
 

--- a/docs/pages/pii.html
+++ b/docs/pages/pii.html
@@ -1,6 +1,7 @@
 ---
 title: Personally Identifiable Information
 layout: layout_docs
+redirect_to: https://docs.publishing.service.gov.uk/analytics/pii.html
 ---
 <h1 class="govuk-heading-l">{{ page.title }}</h1>
 

--- a/docs/pages/trackers.html
+++ b/docs/pages/trackers.html
@@ -1,6 +1,7 @@
 ---
 title: Trackers
 layout: layout_docs
+redirect_to: https://docs.publishing.service.gov.uk/analytics/trackers.html
 ---
 <h1 class="govuk-heading-l">{{ page.title }}</h1>
 <p class="govuk-body">Trackers are distinct JavaScripts that collect GA4 data in specific ways. They work differently but produce and send data to GA4 in the same way.</p>


### PR DESCRIPTION
Uses the [jekyll-redirect-from plugin](https://github.com/jekyll/jekyll-redirect-from) to redirect all section URLs to their  https://docs.publishing.service.gov.uk/analytics/ equivalents.

We need this for users who may have previously bookmarked these old URLs.

This plugin creates the appropriate redirect HTML pages when the site is built.

[Trello](https://trello.com/c/Az4pJo5u/574-decommission-the-old-implementation-record)